### PR TITLE
declare & linebreak arguments for clarity & explicitness

### DIFF
--- a/R/rand_forest_data.R
+++ b/R/rand_forest_data.R
@@ -22,7 +22,12 @@ ordinal_forest_wrapper <- function(x, y, ...) {
 make_rand_forest_ordinalForest <- function() {
 
   parsnip::set_model_engine("rand_forest", "classification", "ordinalForest")
-  parsnip::set_dependency("rand_forest", "ordinalForest", "ordinalForest", mode = "classification")
+  parsnip::set_dependency(
+    "rand_forest",
+    eng = "ordinalForest",
+    pkg = "ordinalForest",
+    mode = "classification"
+  )
 
   parsnip::set_model_arg(
     model = "rand_forest",


### PR DESCRIPTION
I struggled for a bit to understand how this call made sense in comparison to other examples. So i thought it would help to make the arguments explicit to communicate that, indeed, the package being dependencied is {ordinalForest}, not {ordered}. The change is also consistent with [the Tidyverse style guide](https://style.tidyverse.org/syntax.html#long-function-calls).